### PR TITLE
Fix error NU1003 for .net core 2.0

### DIFF
--- a/Vue2Spa.csproj
+++ b/Vue2Spa.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
-    <PackageTargetFallback>$(PackageTargetFallback);portable-net45+win8+wp8+wpa81;</PackageTargetFallback>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore" Version="2.0.0" />


### PR DESCRIPTION
Issue #57 

Error message:  error NU1003: PackageTargetFallback and AssetTargetFallback cannot be used together.
Remove PackageTargetFallback(deprecated) references from the project environment.

See: https://stackoverflow.com/questions/45569378/upgrading-to-net-core-2-0-packagetargetfallback-and-assettargetfallback-cannot