### PR TITLE
Use AspNetCore.All metapackage

### DIFF
--- a/Vue2Spa.csproj
+++ b/Vue2Spa.csproj
@@ -3,11 +3,7 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore" Version="2.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.SpaServices" Version="2.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.3" />
   </ItemGroup>
   <ItemGroup>
     <DotNetCliToolReference Include="Microsoft.DotNet.Watcher.Tools" Version="1.0.1" />


### PR DESCRIPTION
Using the `Microsoft.AspNetCore.All` metapackage makes it easier to keep all the ASP.NET Core packages up to date (and synchronized in versions). It also cuts down on the need to manually hunt for ASP.NET Core packages when you're adding features to a project.

I also bumped the version to 2.0.3. 👍 