### PR TITLE
Update for ASP.NET Core 2.x patterns

### DIFF
--- a/content/Program.cs
+++ b/content/Program.cs
@@ -1,5 +1,5 @@
-using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore;
+using Microsoft.AspNetCore.Hosting;
 
 namespace Vue2Spa
 {
@@ -7,12 +7,11 @@ namespace Vue2Spa
     {
         public static void Main(string[] args)
         {
-            BuildWebHost(args).Run();
+            CreateWebHostBuilder(args).Build().Run();
         }
 
-        public static IWebHost BuildWebHost(string[] args) =>
+        public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
            WebHost.CreateDefaultBuilder(args)
-               .UseStartup<Startup>()
-               .Build();
+               .UseStartup<Startup>();
     }
 }

--- a/content/Startup.cs
+++ b/content/Startup.cs
@@ -1,26 +1,19 @@
-using System;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.SpaServices.Webpack;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 
 namespace Vue2Spa
 {
     public class Startup
     {
-        public Startup(IHostingEnvironment env)
+        public Startup(IConfiguration configuration)
         {
-            var builder = new ConfigurationBuilder()
-                .SetBasePath(env.ContentRootPath)
-                .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
-                .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true)
-                .AddEnvironmentVariables();
-            Configuration = builder.Build();
+            Configuration = configuration;
         }
 
-        public IConfigurationRoot Configuration { get; }
+        public IConfiguration Configuration { get; }
 
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
@@ -33,11 +26,8 @@ namespace Vue2Spa
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
+        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
         {
-            loggerFactory.AddConsole(Configuration.GetSection("Logging"));
-            loggerFactory.AddDebug();
-
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();

--- a/content/appsettings.Development.json
+++ b/content/appsettings.Development.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Debug",
+      "System": "Information",
+      "Microsoft": "Information"
+    }
+  }
+}

--- a/content/appsettings.json
+++ b/content/appsettings.json
@@ -1,11 +1,8 @@
 {
   "ConnectionStrings": {},
   "Logging": {
-    "IncludeScopes": false,
     "LogLevel": {
-      "Default": "Debug",
-      "System": "Information",
-      "Microsoft": "Information"
+      "Default": "Warning"
     }
   }
 }


### PR DESCRIPTION
Some minor adjustments to make this starter template more in-line with the current practices, and to fix double logging output.

---

In ASP.NET Core 2, configuration moved up to the web host builder, so the Startup class should not create its own configuration builder but just have the existing configuration injected.

Similarly, logging also moved up and is part of the default web host builder. Registering providers on the logger factory again will just cause the logging messages to be duplicated (e.g. there were two parallel console loggers before).

- Use `CreateWebHostBuilder` pattern found in ASP.NET Core 2.1.
- Add default `appsettings.json` and `appsettings.Development.json`.