### PR TITLE
Add .vs folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 # Make sure nupkg files don't get pushed to git repo
 **/*.nupkg
+/.vs


### PR DESCRIPTION
.vs folder is the folder created automatically during opening the project in Visual Studio.
Visual Studio uses the folder to store opened documents, breakpoints, machine- and user-specific files and other information about state of the solution.
So this folder should be added to .gitignore